### PR TITLE
Build several pyinstaller files

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,19 +56,19 @@ jobs:
             ARTIFACT_NAME: hello_linux.zip
             ARTIFACT_MIME: application/zip
             CMD_ZIP: |
-              zip --junk-paths hello_linux.zip dist/*
+              (cd dist/hello-world && zip -r hello_linux.zip *)
           - os: macos-latest
             TARGET: macos
             ARTIFACT_NAME: hello_macos.zip
             ARTIFACT_MIME: application/zip
             CMD_ZIP: |
-              zip --junk-paths hello_macos.zip dist/*
+              (cd dist/hello-world && zip -r hello_linux.zip *)
           - os: windows-latest
             TARGET: windows
             ARTIFACT_NAME: hello_windows.zip
             ARTIFACT_MIME: application/zip
             CMD_ZIP: |
-              7z a hello_windows.zip .\dist\*
+              7z a hello_windows.zip .\dist\hello-world\*
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -81,7 +81,7 @@ jobs:
           pip install -r requirements.txt pyinstaller
       - name: Build for ${{ matrix.TARGET }}
         run: |
-          pyinstaller src/cli.py --name hello-world --onefile
+          pyinstaller src/cli.py --name hello-world
       - name: Package .zip for ${{ matrix.TARGET }}
         run: ${{ matrix.CMD_ZIP }}
       - name: Load previously uploaded release URL

--- a/README.md
+++ b/README.md
@@ -1,37 +1,55 @@
 # Release Python Project as PyInstaller Executable on Multiple OSs
 
 This repository provides you with an example of how to deploy a Python project as a PyInstaller
-executable to multiple OSs. PyInstaller allows to create an executable out of the Python project. To
-build the executable for a specific OS, the build command has to be run on this OS.
-On every pushed `v*` tag, the [Release](.github/workflows/release.yaml) workflow does exactly this
-and publishes a release for the OSs `ubuntu-lates`, `macos-latest` and `windows-latest`.
+executable, which does not require Python, to multiple OSs. PyInstaller allows to create an
+executable out of the Python project. To build the executable for a specific OS, the build command
+has to be run on this OS. On every pushed `v*` tag, the [Release](.github/workflows/release.yaml)
+workflow does exactly this and publishes a release for the OSs `ubuntu-latest`, `macos-latest`
+and `windows-latest`.
 
 ## Release Workflow
 
 The [Release](.github/workflows/release.yaml) workflow executes the following steps.
 
-1. Create GitHub release
-2. Store URL of release to attach further artifacts
-3. Set up Python environment on different machines
-4. Install project dependencies (incl. PyInstaller)
-5. Create executable with PyInstaller
-6. Package executable in .zip
-7. Publish .zip with built executable to previous release via URL
+1. Run unit tests
+2. Create GitHub release
+3. Store URL of release to attach further artifacts
+4. Set up Python environment on different machines
+5. Install project dependencies (incl. PyInstaller)
+6. Create executable with PyInstaller
+7. Package executable in .zip
+8. Publish .zip with built executable to previous release via URL
 
 ## Release Tags
 
 The [Release](.github/workflows/release.yaml) workflow is triggered by every tag which starts
 with `v*`, e.g. `v0.3.2`. It then creates a release for this tag with the name of the tag. To tag a
-current state of the repo, create a tag with `git tag v1.4.3` and push the tag
+current state of the repo, create a tag with, for example, `git tag v1.4.3` and push the tag
 with `git push --tags`.
 
 ## Create Executable With PyInstaller
 
-The example application greats either the person specified as an argument or the world if no one is
-specified. The following steps create an executable for your machine.
+The example application greets either the person specified as an argument or the world if no one is
+specified. The following steps create an executable for your machine which does not require Python.
 
 1. Install PyInstaller with `pip install pyinstaller`
 2. Execute `pyinstaller src/cli.py --name hello-world --onefile`
 3. Test single executable `dist/hello-world`
-    1. With arg: `./dist/hello-world Carla`
-    2. Without arg: `./dist/hello-world`
+   1. With arg: `./dist/hello-world Carla`
+   2. Without arg: `./dist/hello-world`
+
+## Run Released Executable
+
+Before running a released executable, it has to be downloaded and unpacked. The archive contains a
+folder `hello_*.zip`. The folder contains an executable `hello-world*` which runs the programme.
+The created executables do not require a Python installation to run. On a linux machine, the run can
+look like this.
+
+```shell
+$ ./hello_linux/hello-world
+> Hello, World!
+```
+
+> MacOS issues security warnings for the downloaded executables. If you do not want to except them,
+> you can download the source code and create an executable with the described steps (requires
+> Python).


### PR DESCRIPTION
When not selecting the option `--one-file` with pyinstaller, the execution of the resulting programme is faster.

Also:
* Add description for unit tests
* Add section about executables with hint about MacOS
* Refine text at several places